### PR TITLE
Add parentheses to example function call for late python3 compat

### DIFF
--- a/StemmerByNikola.py
+++ b/StemmerByNikola.py
@@ -432,5 +432,5 @@ def stem_str(str):
 out = stem_arr("Jovica je išao u školu. Marija je dobra devojka.")
 out2 = stem_str("Jovica je išao u školu. Marija je dobra devojka.")
 
-print out
-print out2
+print (out)
+print (out2)


### PR DESCRIPTION
Hi, just wanted to fix up a little syntax error that stops the code from running cleanly on latest Python 3.8.5

Thanks for all your great work on this library :) 

![image](https://user-images.githubusercontent.com/1173045/92326736-3bbcba80-f022-11ea-8701-86e2a1e862bd.png)

